### PR TITLE
feat(macos): cross-platform CA install, proxy, UI, dialogs

### DIFF
--- a/app/ca_setup.py
+++ b/app/ca_setup.py
@@ -168,6 +168,53 @@ def prepare_mitm_confdir(app_root: Path) -> tuple[Path, str]:
     )
 
 
+def install_ca(app_root: Path) -> tuple[bool, str]:
+    """Platform-aware CA trust install: certutil on Windows, security on macOS."""
+    if sys.platform == "darwin":
+        return install_ca_macos(app_root)
+    return install_ca_windows(app_root)
+
+
+def install_ca_macos(app_root: Path) -> tuple[bool, str]:
+    """Import public CA into macOS login keychain trust store via security(1)."""
+    cer = app_root / CER_NAME
+    if not cer.is_file():
+        try:
+            prepare_mitm_confdir(app_root)
+        except Exception:
+            pass
+        cer = ensure_beside(app_root, CER_NAME) or (app_root / CER_NAME)
+    if not cer.is_file():
+        return False, f"未找到 {CER_NAME} / {P12_PUBLIC}，请先启动一次抓包代理生成证书"
+    keychain = str(Path.home() / "Library" / "Keychains" / "login.keychain-db")
+    # 1) Try to add as a trusted root for the current user (may prompt for password)
+    cmd = ["security", "add-trusted-cert", "-d", "-r", "trustRoot", "-k", keychain, str(cer)]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False
+        )
+        out = ((proc.stdout or "") + "\n" + (proc.stderr or "")).strip()
+        if proc.returncode == 0:
+            return True, "已将 CA 加入 macOS 登录钥匙串信任根。请重启微信后再抓包。（若弹出密码框，请输入本机密码）"
+        # 2) Fallback: add certificate only + ask user to trust manually
+        proc2 = subprocess.run(
+            ["security", "add-certificates", str(cer)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", check=False,
+        )
+        if proc2.returncode == 0:
+            return (
+                False,
+                "已导入证书，但系统信任设置需要手动完成：打开「钥匙串访问」→ 系统/登录 → 双击 "
+                "mitmproxy-ca-cert → 信任 → 选择「始终信任」。\n\n"
+                f"security 输出：{out or '（无）'}",
+            )
+        return False, f"证书导入失败：{out or (proc2.stderr or '未知错误')}"
+    except FileNotFoundError:
+        return False, "未找到 security 命令，请手动在钥匙串访问中导入 mitmproxy-ca-cert.cer"
+    except Exception as exc:  # noqa: BLE001
+        return False, f"证书安装异常：{exc}"
+
+
 def install_ca_windows(app_root: Path) -> tuple[bool, str]:
     """Import public CA into Current User Root store via certutil."""
     cer = app_root / CER_NAME
@@ -227,6 +274,9 @@ def open_p12_in_explorer(app_root: Path) -> tuple[bool, str]:
         p = ensure_beside(app_root, name) or _find(app_root, name)
         if p is not None:
             try:
+                if sys.platform == "darwin":
+                    subprocess.Popen(["open", "-R", str(p)])
+                    return True, f"已在访达中定位：{p}"
                 subprocess.Popen(["explorer", "/select,", str(p)])
                 return True, f"已在资源管理器中定位：{p}"
             except Exception as exc:  # noqa: BLE001

--- a/app/mitm_capture.py
+++ b/app/mitm_capture.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -18,6 +20,62 @@ except ImportError:  # pragma: no cover
     winreg = None  # type: ignore
 
 
+# ── macOS system-proxy helpers (networksetup / scutil) ───────────────
+
+def _mac_default_service() -> str | None:
+    """Return the networksetup service name bound to the default route (e.g. 'Wi-Fi')."""
+    try:
+        out = subprocess.check_output(["route", "-n", "get", "default"], text=True)
+    except Exception:
+        return None
+    dev: str | None = None
+    for line in out.splitlines():
+        line = line.strip()
+        if line.startswith("interface:"):
+            dev = line.split(":", 1)[1].strip()
+    if not dev:
+        return None
+    try:
+        hp = subprocess.check_output(
+            ["networksetup", "-listallhardwareports"], text=True
+        )
+    except Exception:
+        return None
+    svc: str | None = None
+    cur: str | None = None
+    for line in hp.splitlines():
+        line = line.strip()
+        if line.startswith("Hardware Port:"):
+            cur = line.split(":", 1)[1].strip()
+        elif line.startswith("Device:") and line.split(":", 1)[1].strip() == dev:
+            svc = cur
+    return svc
+
+
+def _mac_read_proxy(svc: str, kind: str) -> dict[str, object]:
+    """kind: 'web' or 'secure'. Returns {enabled, server, port} of current settings."""
+    cmd = f"-get{'securewebproxy' if kind == 'secure' else 'webproxy'}"
+    try:
+        out = subprocess.check_output(["networksetup", cmd, svc], text=True)
+    except Exception:
+        return {"enabled": False}
+    state: dict[str, object] = {"enabled": False}
+    for line in out.splitlines():
+        k, _, v = line.partition(":")
+        k = k.strip().lower()
+        v = v.strip()
+        if k == "enabled":
+            state["enabled"] = v.lower() in ("yes", "true", "1")
+        elif k == "server":
+            state["server"] = v
+        elif k == "port":
+            try:
+                state["port"] = int(v)
+            except ValueError:
+                pass
+    return state
+
+
 class MitmCaptureService:
     """Run DumpMaster inside a daemon thread — avoids frozen-exe SSL DLL relaunch bugs."""
 
@@ -26,6 +84,7 @@ class MitmCaptureService:
         self.inbox = app_root / "data" / "capture_inbox.jsonl"
         self._lock = threading.RLock()
         self._proxy_backup: dict[str, Any] | None = None
+        self._mac_proxy_backup: dict[str, dict[str, object]] | None = None
         self._inbox_offset: int = 0
         self._thread: threading.Thread | None = None
         self._master: Any = None
@@ -234,9 +293,64 @@ class MitmCaptureService:
                 msg_parts.append(m if ok else f"恢复系统代理失败：{m}")
             return True, "；".join(msg_parts) if msg_parts else "代理未在运行"
 
+    def _mac_set_system_proxy(self, enable: bool) -> tuple[bool, str]:
+        """Set/restore macOS HTTP+HTTPS proxy for the active network service."""
+        svc = _mac_default_service()
+        if not svc:
+            return False, "无法识别当前网络服务，请手动设置系统代理 127.0.0.1:8088"
+        try:
+            if enable:
+                if self._mac_proxy_backup is None:
+                    self._mac_proxy_backup = {
+                        "web": _mac_read_proxy(svc, "web"),
+                        "secure": _mac_read_proxy(svc, "secure"),
+                    }
+                for kind in ("web", "secure"):
+                    setter = "setsecurewebproxy" if kind == "secure" else "setwebproxy"
+                    subprocess.run(
+                        ["networksetup", setter, svc, PROXY_HOST, str(PROXY_PORT)],
+                        check=True, capture_output=True, text=True,
+                    )
+                for kind in ("web", "secure"):
+                    stater = "setsecurewebproxystate" if kind == "secure" else "setwebproxystate"
+                    subprocess.run(
+                        ["networksetup", stater, svc, "on"],
+                        check=True, capture_output=True, text=True,
+                    )
+                return True, f"已设置系统代理（{svc}）→ 127.0.0.1:8088"
+            # restore
+            backup, self._mac_proxy_backup = self._mac_proxy_backup, None
+            if backup:
+                for kind in ("web", "secure"):
+                    st = backup.get(kind) or {}
+                    setter = "setsecurewebproxy" if kind == "secure" else "setwebproxy"
+                    stater = "setsecurewebproxystate" if kind == "secure" else "setwebproxystate"
+                    if st.get("server"):
+                        subprocess.run(
+                            ["networksetup", setter, svc, str(st["server"]), str(st.get("port") or 80)],
+                            check=True, capture_output=True, text=True,
+                        )
+                    subprocess.run(
+                        ["networksetup", stater, svc, "on" if st.get("enabled") else "off"],
+                        check=True, capture_output=True, text=True,
+                    )
+            else:
+                for stater in ("setwebproxystate", "setsecurewebproxystate"):
+                    subprocess.run(
+                        ["networksetup", stater, svc, "off"],
+                        check=True, capture_output=True, text=True,
+                    )
+            return True, "已恢复系统代理设置（macOS）"
+        except subprocess.CalledProcessError as exc:
+            return False, f"networksetup 执行失败：{exc.stderr or exc}"
+        except Exception as exc:  # noqa: BLE001
+            return False, f"设置系统代理异常：{exc}"
+
     def enable_system_proxy(self) -> tuple[bool, str]:
+        if sys.platform == "darwin":
+            return self._mac_set_system_proxy(True)
         if winreg is None:
-            return False, "非 Windows，请手动设置 HTTP 代理 127.0.0.1:8088"
+            return False, "非 Windows/macOS，请手动设置 HTTP 代理 127.0.0.1:8088"
         try:
             key = winreg.OpenKey(
                 winreg.HKEY_CURRENT_USER,
@@ -264,6 +378,8 @@ class MitmCaptureService:
             return False, str(exc)
 
     def restore_system_proxy(self) -> tuple[bool, str]:
+        if sys.platform == "darwin":
+            return self._mac_set_system_proxy(False)
         if winreg is None or self._proxy_backup is None:
             return True, "无需恢复系统代理"
         try:

--- a/app/ui.py
+++ b/app/ui.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import queue
 import re
+import sys
 import threading
 import time
 import webbrowser
@@ -17,6 +18,10 @@ import customtkinter as ctk
 import pyperclip
 from PIL import Image
 
+# UI font: PingFang SC on macOS, Microsoft YaHei UI on Windows
+UI_FONT = "PingFang SC" if sys.platform == "darwin" else "Microsoft YaHei UI"
+MONO_FONT = "Menlo" if sys.platform == "darwin" else "Consolas"
+
 from app.article_reader import (
     ARTICLE_EXPORT_FORMATS,
     ARTICLE_EXPORT_LABELS,
@@ -26,7 +31,12 @@ from app.article_reader import (
     format_key_for_article_label,
     write_article_export,
 )
-from app.ca_setup import PROXY_HOST, PROXY_PORT, install_ca_windows, open_p12_in_explorer
+from app.ca_setup import (
+    PROXY_HOST,
+    PROXY_PORT,
+    install_ca as install_ca_platform,
+    open_p12_in_explorer,
+)
 from app.capture_target import expected_biz, resolve_capture_target
 from app.batch_import import BatchRow, parse_batch_import
 from app.clipboard_watch import ClipboardWatcher
@@ -135,7 +145,7 @@ class AccountCard(ctk.CTkFrame):
         self.name_lbl = ctk.CTkLabel(
             top,
             text=account.get("name") or "未命名",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=16, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=16, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         )
@@ -144,7 +154,7 @@ class AccountCard(ctk.CTkFrame):
         self.timer_lbl = ctk.CTkLabel(
             top,
             text="",
-            font=ctk.CTkFont(family="Consolas", size=15, weight="bold"),
+            font=ctk.CTkFont(family=MONO_FONT, size=15, weight="bold"),
             text_color=COLORS["accent"],
             anchor="e",
         )
@@ -153,7 +163,7 @@ class AccountCard(ctk.CTkFrame):
         self.meta_lbl = ctk.CTkLabel(
             self,
             text="",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -172,7 +182,7 @@ class AccountCard(ctk.CTkFrame):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#0b1412",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=lambda: self.app.copy_credentials(self.account_id),
         )
         self.copy_btn.pack(side="left", padx=(0, 14))
@@ -186,7 +196,7 @@ class AccountCard(ctk.CTkFrame):
             fg_color=COLORS["warn"],
             hover_color="#ebab6e",
             text_color="#1a1208",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=lambda: self.app.renew_account(self.account_id),
         )
         self.renew_btn.pack(side="left", padx=(0, 14))
@@ -200,7 +210,7 @@ class AccountCard(ctk.CTkFrame):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=lambda: self.app.open_article(self.account_id),
         )
         self.open_btn.pack(side="left", padx=(0, 14))
@@ -216,7 +226,7 @@ class AccountCard(ctk.CTkFrame):
             border_color=COLORS["danger"],
             hover_color="#3a2222",
             text_color=COLORS["danger"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=lambda: self.app.delete_account(self.account_id),
         )
         self.del_btn.pack(side="left")
@@ -372,7 +382,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             title_row,
             text="Schinza",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=20, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=20, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).pack(side="left")
@@ -380,7 +390,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             header,
             text=f"凭证 {TTL_MINUTES} 分钟 · 历史文章 · HTML / MD / TXT / JSON / Word",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="e",
         ).grid(row=0, column=1, sticky="e", padx=20)
@@ -400,7 +410,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             side,
             text="栏目",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=11),
+            font=ctk.CTkFont(family=UI_FONT, size=11),
             text_color=COLORS["muted"],
             anchor="w",
         ).grid(row=0, column=0, sticky="ew", padx=18, pady=(20, 8))
@@ -416,7 +426,7 @@ class CertificateApp(ctk.CTk):
                 fg_color=COLORS["nav_idle"],
                 hover_color=COLORS["border"],
                 text_color=COLORS["text"],
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=14, weight="bold"),
+                font=ctk.CTkFont(family=UI_FONT, size=14, weight="bold"),
                 anchor="w",
                 command=lambda k=key: self._show_tab(k),
             )
@@ -431,7 +441,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["nav_idle"],
             hover_color=COLORS["border"],
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             anchor="w",
             command=self.manual_check_update,
         )
@@ -455,6 +465,21 @@ class CertificateApp(ctk.CTk):
         return None
 
     def _apply_window_icon(self) -> None:
+        if sys.platform == "darwin":
+            # macOS: wm_iconphoto with a PNG PhotoImage (iconbitmap only accepts .icns)
+            png = self._resolve_asset("logo-128.png") or self._resolve_asset("logo.png")
+            if png is not None:
+                try:
+                    from PIL import ImageTk
+
+                    img = ImageTk.PhotoImage(
+                        Image.open(png).resize((128, 128), Image.LANCZOS)
+                    )
+                    self._window_icon_photo = img  # keep a reference alive
+                    self.wm_iconphoto(True, img)
+                except Exception:
+                    pass
+            return
         ico = self._resolve_asset("schinza.ico")
         if ico is None:
             return
@@ -517,7 +542,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             panel,
             text="① 首次使用：安装抓包证书（MITM CA）",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, sticky="w", padx=18, pady=(14, 4))
@@ -529,7 +554,7 @@ class CertificateApp(ctk.CTk):
                 f"程序会启动本地代理 {PROXY_HOST}:{PROXY_PORT}，并使用随包附带的 mitmproxy-ca-cert.p12。"
                 "每人只需安装一次 CA，然后重启微信。"
             ),
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -548,7 +573,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self.install_ca,
         ).pack(side="left", padx=(0, 16))
 
@@ -572,7 +597,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=self.toggle_proxy,
         )
         self.proxy_btn.pack(side="left", padx=(0, 16))
@@ -580,7 +605,7 @@ class CertificateApp(ctk.CTk):
         self.proxy_lbl = ctk.CTkLabel(
             panel,
             text="代理未启动 · 请优先用下方「添加并抓包」（会自动启动代理）",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -602,7 +627,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             form,
             text="添加公众号",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
         ).grid(row=0, column=0, columnspan=3, sticky="w", padx=18, pady=(14, 8))
 
@@ -610,7 +635,7 @@ class CertificateApp(ctk.CTk):
             form,
             text="名称",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         ).grid(row=1, column=0, sticky="w", padx=(18, 8), pady=6)
 
         self.name_entry = ctk.CTkEntry(
@@ -621,7 +646,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             fg_color=COLORS["card"],
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         )
         self.name_entry.grid(row=1, column=1, columnspan=2, sticky="ew", padx=(0, 18), pady=6)
 
@@ -629,7 +654,7 @@ class CertificateApp(ctk.CTk):
             form,
             text="文章链接",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         ).grid(row=2, column=0, sticky="w", padx=(18, 8), pady=6)
 
         self.url_entry = ctk.CTkEntry(
@@ -640,7 +665,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             fg_color=COLORS["card"],
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         )
         self.url_entry.grid(row=2, column=1, sticky="ew", padx=(0, 10), pady=6)
 
@@ -653,7 +678,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#0b1412",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self.add_account,
         )
         self.add_btn.grid(row=2, column=2, sticky="e", padx=(0, 18), pady=6)
@@ -668,7 +693,7 @@ class CertificateApp(ctk.CTk):
                 "再在微信桌面打开该公众号任意一篇文章。"
             ),
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             anchor="w",
             justify="left",
             wraplength=700,
@@ -710,7 +735,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             head,
             text="已添加公众号",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, sticky="w")
@@ -724,7 +749,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["warn"],
             hover_color="#ebab6e",
             text_color="#1a1208",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self.renew_all_accounts,
         ).grid(row=0, column=1, sticky="e")
 
@@ -736,7 +761,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             fg_color=COLORS["card"],
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
         )
         self.search_entry.grid(row=1, column=0, columnspan=2, sticky="ew", pady=(6, 0))
         self.search_entry.bind("<KeyRelease>", lambda _e: self._apply_name_filter())
@@ -763,7 +788,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             panel,
             text="拉取公众号历史文章",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, columnspan=4, sticky="w", padx=18, pady=(14, 4))
@@ -771,7 +796,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             panel,
             text="选择公众号与时间范围后拉取；支持列表导出与正文导出（HTML / Markdown / TXT / JSON / Word）。",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -782,7 +807,7 @@ class CertificateApp(ctk.CTk):
             panel,
             text="公众号",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         ).grid(row=2, column=0, sticky="w", padx=(18, 8), pady=6)
 
         self.hist_account_menu = ctk.CTkOptionMenu(
@@ -794,8 +819,8 @@ class CertificateApp(ctk.CTk):
             button_color=COLORS["border"],
             button_hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
-            dropdown_font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
+            dropdown_font=ctk.CTkFont(family=UI_FONT, size=13),
             command=self._on_hist_account_change,
         )
         self.hist_account_menu.grid(row=2, column=1, sticky="ew", padx=(0, 10), pady=6)
@@ -811,8 +836,8 @@ class CertificateApp(ctk.CTk):
             button_color=COLORS["border"],
             button_hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
-            dropdown_font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
+            dropdown_font=ctk.CTkFont(family=UI_FONT, size=13),
             command=self._on_history_range_change,
         )
         self.hist_range_menu.set(self._history_range_label())
@@ -827,7 +852,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self.start_history_fetch,
         )
         self.hist_fetch_btn.grid(row=2, column=3, sticky="e", padx=(0, 18), pady=6)
@@ -836,7 +861,7 @@ class CertificateApp(ctk.CTk):
             panel,
             text="请选择公众号与时间范围后点击拉取。",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             anchor="w",
             justify="left",
             wraplength=720,
@@ -850,7 +875,7 @@ class CertificateApp(ctk.CTk):
             list_tools,
             text="列表导出",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
         ).pack(side="left", padx=(0, 10))
 
         self.hist_format_menu = ctk.CTkOptionMenu(
@@ -863,8 +888,8 @@ class CertificateApp(ctk.CTk):
             button_color=COLORS["border"],
             button_hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
-            dropdown_font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
+            dropdown_font=ctk.CTkFont(family=UI_FONT, size=12),
         )
         self.hist_format_menu.set(FORMAT_LABELS[0])
         self.hist_format_menu.pack(side="left", padx=(0, 14))
@@ -889,7 +914,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=12, weight="bold"),
             command=self.export_history_file,
         ).pack(side="left", padx=(0, 20))
 
@@ -922,7 +947,7 @@ class CertificateApp(ctk.CTk):
             batch_tools,
             text="正文导出",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
         ).pack(side="left", padx=(0, 10))
 
         self.article_fmt_menu = ctk.CTkOptionMenu(
@@ -935,8 +960,8 @@ class CertificateApp(ctk.CTk):
             button_color=COLORS["border"],
             button_hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
-            dropdown_font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
+            dropdown_font=ctk.CTkFont(family=UI_FONT, size=12),
         )
         self.article_fmt_menu.set("Markdown")
         self.article_fmt_menu.pack(side="left", padx=(0, 14))
@@ -972,7 +997,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=12, weight="bold"),
             command=self.batch_export_selected,
         )
         self.batch_export_btn.pack(side="left", padx=(0, 14))
@@ -985,7 +1010,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             list_wrap,
             text="文章列表（勾选后可批量导出正文）",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, sticky="w", pady=(0, 10))
@@ -1016,7 +1041,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             panel,
             text="同步服务器",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=15, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=15, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, columnspan=4, sticky="w", padx=18, pady=(14, 4))
@@ -1024,7 +1049,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             panel,
             text="导入 Schinza 公众号列表，将本地有效凭证按名称匹配后分批上传（每批 ≤ 50）。",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -1035,7 +1060,7 @@ class CertificateApp(ctk.CTk):
             panel,
             text="服务器地址",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         ).grid(row=2, column=0, sticky="w", padx=(18, 8), pady=6)
 
         self.sync_base_entry = ctk.CTkEntry(
@@ -1047,7 +1072,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             text_color=COLORS["text"],
             placeholder_text="https://example.com/schinza",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
         )
         self.sync_base_entry.grid(row=2, column=1, sticky="w", padx=(0, 10), pady=6)
 
@@ -1060,7 +1085,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=self._import_school_accounts,
         ).grid(row=2, column=2, sticky="w", padx=(0, 10), pady=6)
 
@@ -1073,7 +1098,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self._sync_upload,
         )
         self.sync_upload_btn.grid(row=2, column=3, sticky="e", padx=(0, 18), pady=6)
@@ -1082,7 +1107,7 @@ class CertificateApp(ctk.CTk):
             panel,
             text="尚未导入公众号列表。",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             anchor="w",
             justify="left",
             wraplength=720,
@@ -1104,7 +1129,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["warn"],
             hover_color="#ebab6e",
             text_color="#1a1208",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=self._copy_all_credentials,
         )
         self.sync_copy_btn.pack(side="left", padx=(0, 14))
@@ -1113,7 +1138,7 @@ class CertificateApp(ctk.CTk):
             btns,
             text="同步会将匹配到的凭证提交到上方服务器地址，请确认可信后再操作。",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             anchor="w",
         ).pack(side="left")
 
@@ -1128,7 +1153,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             border_width=1,
             corner_radius=12,
-            font=ctk.CTkFont(family="Consolas", size=12),
+            font=ctk.CTkFont(family=MONO_FONT, size=12),
             text_color=COLORS["muted"],
             wrap="none",
         )
@@ -1140,7 +1165,7 @@ class CertificateApp(ctk.CTk):
             self,
             text="Schinza · MIT License · 凭证保存在本机 data/ · 同步上传前请确认目标服务器可信",
             text_color=COLORS["muted"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=11),
+            font=ctk.CTkFont(family=UI_FONT, size=11),
         )
         foot.grid(row=2, column=0, sticky="ew", padx=24, pady=(0, 12))
 
@@ -1449,7 +1474,7 @@ class CertificateApp(ctk.CTk):
     # ── credentials tab actions ───────────────────────────────────────
 
     def install_ca(self) -> None:
-        ok, msg = install_ca_windows(self.root_dir)
+        ok, msg = install_ca_platform(self.root_dir)
         self.proxy_lbl.configure(text=msg, text_color=COLORS["ok"] if ok else COLORS["danger"])
         self.set_status(msg, ok=ok)
 
@@ -1595,7 +1620,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text=headline,
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=16, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=16, weight="bold"),
             text_color=COLORS["ok"] if ok else COLORS["danger"],
             anchor="w",
         ).grid(row=0, column=0, sticky="ew", padx=18, pady=(16, 4))
@@ -1603,7 +1628,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text=body,
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -1628,7 +1653,7 @@ class CertificateApp(ctk.CTk):
                 hover_color=COLORS["accent_hover"],
                 text_color="#0b1412",
                 font=ctk.CTkFont(
-                    family="Microsoft YaHei UI", size=13, weight="bold"
+                    family=UI_FONT, size=13, weight="bold"
                 ),
                 command=lambda: (on_action(), close()),
             ).pack(side="right", padx=(8, 0))
@@ -1642,7 +1667,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=close,
         ).pack(side="right")
 
@@ -2004,7 +2029,7 @@ class CertificateApp(ctk.CTk):
                 self.list_frame,
                 text=empty_text,
                 text_color=COLORS["muted"],
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+                font=ctk.CTkFont(family=UI_FONT, size=13),
             )
             empty.grid(row=0, column=0, pady=40)
             return
@@ -2126,7 +2151,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text="自定义拉取天数",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=16, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=16, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, sticky="ew", padx=18, pady=(16, 4))
@@ -2134,7 +2159,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text=f"请输入要拉取的天数（1 - {MAX_CUSTOM_DAYS}），例如 15 表示近 15 天。",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -2148,7 +2173,7 @@ class CertificateApp(ctk.CTk):
             border_color=COLORS["border"],
             fg_color=COLORS["card"],
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Consolas", size=14),
+            font=ctk.CTkFont(family=MONO_FONT, size=14),
         )
         entry.grid(row=2, column=0, sticky="ew", padx=18, pady=(0, 8))
         entry.insert(0, str(self._history_custom_days or CUSTOM_DAYS_DEFAULT))
@@ -2158,7 +2183,7 @@ class CertificateApp(ctk.CTk):
         err_lbl = ctk.CTkLabel(
             card,
             text="",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=11),
+            font=ctk.CTkFont(family=UI_FONT, size=11),
             text_color=COLORS["danger"],
             anchor="w",
         )
@@ -2195,7 +2220,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=close_cancel,
         ).pack(side="left", padx=(0, 8))
 
@@ -2208,7 +2233,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=confirm,
         ).pack(side="left")
 
@@ -2366,7 +2391,7 @@ class CertificateApp(ctk.CTk):
                 self.hist_list,
                 text="暂无文章。选择有效凭证后点击拉取。",
                 text_color=COLORS["muted"],
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+                font=ctk.CTkFont(family=UI_FONT, size=13),
             ).grid(row=0, column=0, pady=40)
             return
         for i, art in enumerate(self._history_articles):
@@ -2411,7 +2436,7 @@ class CertificateApp(ctk.CTk):
             ctk.CTkLabel(
                 card,
                 text=title,
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=14, weight="bold"),
+                font=ctk.CTkFont(family=UI_FONT, size=14, weight="bold"),
                 text_color=COLORS["text"],
                 anchor="w",
                 justify="left",
@@ -2422,7 +2447,7 @@ class CertificateApp(ctk.CTk):
             ctk.CTkLabel(
                 card,
                 text=meta or link[:72],
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+                font=ctk.CTkFont(family=UI_FONT, size=12),
                 text_color=COLORS["muted"],
                 anchor="w",
                 justify="left",
@@ -2465,8 +2490,8 @@ class CertificateApp(ctk.CTk):
                 button_color=COLORS["border"],
                 button_hover_color="#3a4a5e",
                 text_color=COLORS["text"],
-                font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
-                dropdown_font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+                font=ctk.CTkFont(family=UI_FONT, size=12),
+                dropdown_font=ctk.CTkFont(family=UI_FONT, size=12),
             )
             fmt_menu.set(self.article_fmt_menu.get() if hasattr(self, "article_fmt_menu") else "Markdown")
             fmt_menu.pack(side="left", padx=(0, 12))
@@ -2577,7 +2602,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text="补录文章链接",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=16, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=16, weight="bold"),
             text_color=COLORS["text"],
             anchor="w",
         ).grid(row=0, column=0, sticky="ew", padx=18, pady=(16, 4))
@@ -2585,7 +2610,7 @@ class CertificateApp(ctk.CTk):
         ctk.CTkLabel(
             card,
             text="粘贴公众号文章链接，将合并进当前列表。",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=12),
+            font=ctk.CTkFont(family=UI_FONT, size=12),
             text_color=COLORS["muted"],
             anchor="w",
             justify="left",
@@ -2600,7 +2625,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["card"],
             text_color=COLORS["text"],
             placeholder_text="https://mp.weixin.qq.com/s/…",
-            font=ctk.CTkFont(family="Consolas", size=13),
+            font=ctk.CTkFont(family=MONO_FONT, size=13),
         )
         entry.grid(row=2, column=0, sticky="ew", padx=18, pady=(0, 8))
         entry.focus_set()
@@ -2608,7 +2633,7 @@ class CertificateApp(ctk.CTk):
         err_lbl = ctk.CTkLabel(
             card,
             text="",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=11),
+            font=ctk.CTkFont(family=UI_FONT, size=11),
             text_color=COLORS["danger"],
             anchor="w",
         )
@@ -2643,7 +2668,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["border"],
             hover_color="#3a4a5e",
             text_color=COLORS["text"],
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13),
+            font=ctk.CTkFont(family=UI_FONT, size=13),
             command=close_cancel,
         ).pack(side="left", padx=(0, 8))
 
@@ -2656,7 +2681,7 @@ class CertificateApp(ctk.CTk):
             fg_color=COLORS["accent"],
             hover_color=COLORS["accent_hover"],
             text_color="#052e16",
-            font=ctk.CTkFont(family="Microsoft YaHei UI", size=13, weight="bold"),
+            font=ctk.CTkFont(family=UI_FONT, size=13, weight="bold"),
             command=confirm,
         ).pack(side="left")
 

--- a/main.py
+++ b/main.py
@@ -34,8 +34,8 @@ def _prepare_dll_search(root: Path, res: Path) -> None:
                 os.add_dll_directory(str(d))
             except (OSError, FileNotFoundError):
                 pass
-    prefix = ";".join(str(d) for d in dirs)
-    os.environ["PATH"] = prefix + ";" + os.environ.get("PATH", "")
+    prefix = os.pathsep.join(str(d) for d in dirs)
+    os.environ["PATH"] = prefix + os.pathsep + os.environ.get("PATH", "")
 
 
 def _ensure_stdio(root: Path) -> None:
@@ -65,6 +65,25 @@ def _show_fatal(title: str, exc: BaseException) -> None:
     import traceback
 
     body = f"{title}\n\n{exc}\n\n{traceback.format_exc()}"
+    if sys.platform == "darwin":
+        try:
+            import subprocess
+
+            safe = (
+                body.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " return ")
+            )
+            subprocess.run(
+                [
+                    "osascript",
+                    "-e",
+                    f'display alert "Schinza 凭证助手" message "{safe}" as critical',
+                ],
+                check=False,
+                timeout=5,
+            )
+            return
+        except Exception:
+            pass
     try:
         import ctypes
 


### PR DESCRIPTION
## Summary
macOS 兼容适配：4 个核心模块改为平台感知，Windows 行为完全不变。
已在 macOS 实测，抓包链路打通：可捕获 `__biz` / `uin` / `key` / `pass_ticket` 凭证，可抓取公众号历史文章。

## Changes
- `app/ca_setup.py`：新增 `install_ca()` 平台分发；macOS 用 `security add-trusted-cert` 安装信任根（失败降级为手动信任指引）；文件定位用 `open -R`
- `app/mitm_capture.py`：macOS 用 `networksetup` 自动设置/恢复系统代理（自动识别当前网络服务，备份并还原原代理状态）
- `app/ui.py`：macOS 字体切换为 PingFang SC / Menlo；窗口图标改用 `wm_iconphoto`
- `main.py`：PATH 拼接改用 `os.pathsep`（修复 macOS 分隔符问题）；错误弹窗 macOS 用 `osascript`

## Test
- 环境：macOS arm64 · Python 3.13.12 · customtkinter 6.0.0 · mitmproxy 12.2.3
- 全部模块导入正常；mitmproxy DumpMaster 启动正常
- 实测：凭证捕获成功、getmsg 历史文章抓取成功

## Notes
- Windows 原有代码路径与行为未改动
- 首次安装 CA 在 macOS 上可能弹出系统密码框（属正常安全行为）
